### PR TITLE
New complete replication test

### DIFF
--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -352,6 +352,7 @@ void handler(int sig, siginfo_t *si, void *unused){
 			vm::map_memory(aligned_access_ptr, pagesize*CACHELINE, cacheoffset+offset, PROT_READ|PROT_WRITE);
 
 		}
+
 		sem_post(&ibsem);
 		pthread_mutex_unlock(&cachemutex);
 		return;
@@ -1193,6 +1194,8 @@ void storepageDIFF(unsigned long index, unsigned long addr){
 	// CSPext: Calculate the replication id
 	const argo::node_id_t repl_node = _calc_rid(homenode);
 
+	printf("----storepagediff: Node = %d\n", argo_get_nid());
+
 	char * copy = (char *)(pagecopy + index*pagesize);
 	char * real = (char *)startAddr+addr;
 	size_t drf_unit = sizeof(char);
@@ -1301,16 +1304,16 @@ void get_replicated_data(dd::global_ptr<char> ptr, void* container, unsigned int
 	const argo::node_id_t r = _calc_rid(h);	// repl node id
 	const std::size_t offset = ptr.offset();
 
-	printf("Node %d: array[0] = %d\n", argo_get_nid(), ((int *) (replData + ptr.offset()))[0]);
+	printf("----get repl data: Node %d: array[0] = %d, container[0] = %d\n", getID(), ((int *) (replData + ptr.offset()))[0], ((int *) container)[0]);
 
-	printf("------get repl data: ptr %p container %p\n", ptr.get(), container);
-	printf("------get repl data: h %d r %d offset %lu length %u\n", h, r, offset, len);
+	printf("----get repl data: ptr %p container %p\n", ptr.get(), container);
+	printf("----get repl data: h %d r %d offset %lu length %u\n", h, r, offset, len);
 	
 	if (h == dd::invalid_node_id || r == dd::invalid_node_id) {
 		// TODO: Do nothing and return. Or what should we do?
 		return;
 	}
-	if (argo_get_nid() == r) {
+	if (getID() == r) {
 		memcpy(container, replData + ptr.offset(), len);
 		return;
 	} else {

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -561,7 +561,6 @@ void load_cache_entry(std::size_t aligned_access_offset) {
 
 		/* If another page occupies the cache index, begin to evict it. */
 		if((cacheControl[idx].tag != temp_addr) && (cacheControl[idx].tag != GLOBAL_NULL)){
-			printf("------load cache entry: evict\n");
 			void* old_ptr = static_cast<char*>(startAddr) + cacheControl[idx].tag;
 			void* temp_ptr = static_cast<char*>(startAddr) + temp_addr;
 
@@ -574,7 +573,6 @@ void load_cache_entry(std::size_t aligned_access_offset) {
 				argo_write_buffer->erase(idx);
 			}
 
-			printf("------load cache entry: unlock windows\n");
 			/* Ensure the writeback has finished */
 			for(int i = 0; i < numtasks; i++){
 				argo::node_id_t repl_node_i = _calc_rid(i);	// get replication node
@@ -1194,7 +1192,7 @@ void storepageDIFF(unsigned long index, unsigned long addr){
 	// CSPext: Calculate the replication id
 	const argo::node_id_t repl_node = _calc_rid(homenode);
 
-	printf("----storepagediff: Node = %d\n", argo_get_nid());
+	// printf("----storepagediff: Node = %d\n", argo_get_nid());
 
 	char * copy = (char *)(pagecopy + index*pagesize);
 	char * real = (char *)startAddr+addr;
@@ -1304,10 +1302,9 @@ void get_replicated_data(dd::global_ptr<char> ptr, void* container, unsigned int
 	const argo::node_id_t r = _calc_rid(h);	// repl node id
 	const std::size_t offset = ptr.offset();
 
-	printf("----get repl data: Node %d: array[0] = %d, container[0] = %d\n", getID(), ((int *) (replData + ptr.offset()))[0], ((int *) container)[0]);
-
-	printf("----get repl data: ptr %p container %p\n", ptr.get(), container);
-	printf("----get repl data: h %d r %d offset %lu length %u\n", h, r, offset, len);
+	// printf("----get repl data: Node %d: array[0] = %d, container[0] = %d\n", getID(), ((int *) (replData + ptr.offset()))[0], ((int *) container)[0]);
+	// printf("----get repl data: ptr %p container %p\n", ptr.get(), container);
+	// printf("----get repl data: h %d r %d offset %lu length %u\n", h, r, offset, len);
 	
 	if (h == dd::invalid_node_id || r == dd::invalid_node_id) {
 		// TODO: Do nothing and return. Or what should we do?

--- a/src/backend/mpi/write_buffer.hpp
+++ b/src/backend/mpi/write_buffer.hpp
@@ -167,7 +167,6 @@ class write_buffer
 				// Write back the page
 				mprotect(page_ptr, block_size, PROT_READ);
 				cacheControl[cache_index].dirty=CLEAN;
-				printf("----write buffer: Partial flush in node %d\n", argo_get_nid());
 				for(int i=0; i < CACHELINE; i++){
 					storepageDIFF(cache_index+i,page_size*i+page_address);
 				}
@@ -262,7 +261,6 @@ class write_buffer
 				// Write back the page
 				mprotect(page_ptr, block_size, PROT_READ);
 				cacheControl[cache_index].dirty=CLEAN;
-				printf("----write buffer: Flush in node %d\n", argo_get_nid());
 				for(int i=0; i < CACHELINE; i++){
 					storepageDIFF(cache_index+i,page_size*i+page_address);
 				}

--- a/src/backend/mpi/write_buffer.hpp
+++ b/src/backend/mpi/write_buffer.hpp
@@ -167,6 +167,7 @@ class write_buffer
 				// Write back the page
 				mprotect(page_ptr, block_size, PROT_READ);
 				cacheControl[cache_index].dirty=CLEAN;
+				printf("----write buffer: Partial flush in node %d\n", argo_get_nid());
 				for(int i=0; i < CACHELINE; i++){
 					storepageDIFF(cache_index+i,page_size*i+page_address);
 				}
@@ -261,6 +262,7 @@ class write_buffer
 				// Write back the page
 				mprotect(page_ptr, block_size, PROT_READ);
 				cacheControl[cache_index].dirty=CLEAN;
+				printf("----write buffer: Flush in node %d\n", argo_get_nid());
 				for(int i=0; i < CACHELINE; i++){
 					storepageDIFF(cache_index+i,page_size*i+page_address);
 				}

--- a/tests/replication.cpp
+++ b/tests/replication.cpp
@@ -66,7 +66,7 @@ TEST_F(replicationTest, completeReplicationLocal) {
 
 	char* val = argo::conew_<char>(c_const);
 
-	// TODO: Set == 0 when "page is local" replication bug if fixed!
+	// TODO: Set == 0 when "page is local" replication bug is fixed!
 	if (argo::node_id() == 1) {
 		*val += 1;
 	}
@@ -95,7 +95,7 @@ TEST_F(replicationTest, completeReplicationRemote) {
 
 	char* val = argo::conew_<char>(c_const);
 
-	// TODO: Set == 0 when "page is local" replication bug if fixed!
+	// TODO: Set == 0 when "page is local" replication bug is fixed!
 	if (argo::node_id() == 1) {
 		*val += 1;
 	}
@@ -131,7 +131,7 @@ TEST_F(replicationTest, completeReplicationArray) {
 	}
 
 	// Initialize write buffer
-	// TODO: Set == 0 when "page is local" replication bug if fixed!
+	// TODO: Set == 0 when "page is local" replication bug is fixed!
 	if (argo::node_id() == 1) {
 		for (std::size_t i = 0; i < array_size; i++) {
 			array[i] = 1;

--- a/tests/replication.cpp
+++ b/tests/replication.cpp
@@ -54,59 +54,63 @@ protected:
 	}
 };
 
-// /**
-//  * @brief Simple test that a replicated char can be fetched by its host node
-//  */
-// TEST_F(replicationTest, completeReplicationLocal) {
-// 	// Test not relevant for single node
-// 	if (argo_number_of_nodes() == 1) {
-// 		ASSERT_TRUE(true);
-// 		return;
-// 	}
+/**
+ * @brief Simple test that a replicated char can be fetched by its host node
+ */
+TEST_F(replicationTest, completeReplicationLocal) {
+	// Test not relevant for single node
+	if (argo_number_of_nodes() == 1) {
+		ASSERT_TRUE(true);
+		return;
+	}
 
-// 	global_char val;
-// 	val = argo::conew_<char>(c_const);
+	char* val = argo::conew_<char>(c_const);
 
-// 	*val += 1;		 // All nodes does this!
-// 	argo::barrier(); // Wait until writing is commited
+	// TODO: Set == 0 when "page is local" replication bug if fixed!
+	if (argo::node_id() == 1) {
+		*val += 1;
+	}
+	argo::barrier(); // Wait until writing is commited
 
-// 	char receiver = 'z';
-// 	if (argo::node_id() == argo_get_replnode(val.get())) {
-// 		argo::backend::get_repl_data(val, (void *)(&receiver), 1);
-// 		// printf("orignial val is %x = %c, repl val is %x = %c\n", *val, *val, receiver, receiver);
-// 		ASSERT_EQ(*val, receiver);
-// 	} else {
-// 		// Not target node; automatically passing
-// 		ASSERT_TRUE(true);
-// 	}
-// }
+	char receiver = 'z';
+	if (argo::node_id() == argo_get_replnode(val)) {
+		argo::backend::get_repl_data(val, (void *)(&receiver), 1);
+		// printf("orignial val is %x = %c, repl val is %x = %c\n", *val, *val, receiver, receiver);
+		ASSERT_EQ(*val, receiver);
+	} else {
+		// Not target node; automatically passing
+		ASSERT_TRUE(true);
+	}
+}
 
-// /**
-//  * @brief Test that a replicated char can be fetched by remote nodes
-//  */
-// TEST_F(replicationTest, completeReplicationRemote) {
-// 	// Test not relevant for single node
-// 	if (argo_number_of_nodes() == 1) {
-// 		ASSERT_TRUE(true);
-// 		return;
-// 	}
+/**
+ * @brief Test that a replicated char can be fetched by remote nodes
+ */
+TEST_F(replicationTest, completeReplicationRemote) {
+	// Test not relevant for single node
+	if (argo_number_of_nodes() == 1) {
+		ASSERT_TRUE(true);
+		return;
+	}
 
-// 	global_char val;
-// 	val = argo::conew_<char>(c_const);
+	char* val = argo::conew_<char>(c_const);
 
-// 	*val += 1;
-// 	argo::barrier();
+	// TODO: Set == 0 when "page is local" replication bug if fixed!
+	if (argo::node_id() == 1) {
+		*val += 1;
+	}
+	argo::barrier();
 
-// 	char receiver = 'z';
-// 	if (argo::node_id() != argo_get_replnode(val.get())) {
-// 		argo::backend::get_repl_data(val, (void *)&receiver, 1);
-// 		// printf("orignial val is %x = %c, repl val is %x = %c\n", *val, *val, receiver, receiver);
-// 		ASSERT_EQ(*val, receiver);
-// 	} else {
-// 		// Not target node; automatically passing
-// 		ASSERT_TRUE(true);
-// 	}
-// }
+	char receiver = 'z';
+	if (argo::node_id() != argo_get_replnode(val)) {
+		argo::backend::get_repl_data(val, (void *)&receiver, 1);
+		// printf("orignial val is %x = %c, repl val is %x = %c\n", *val, *val, receiver, receiver);
+		ASSERT_EQ(*val, receiver);
+	} else {
+		// Not target node; automatically passing
+		ASSERT_TRUE(true);
+	}
+}
 
 /**
  * @brief Test that a replicated array can be fetched locally and remotely
@@ -122,30 +126,31 @@ TEST_F(replicationTest, completeReplicationArray) {
 	int* array = argo::conew_array<int>(array_size);
 	int* receiver = new int[array_size];
 
+	for (std::size_t i = 0; i < array_size; i++) {
+		receiver[i] = 0;
+	}
+
 	// Initialize write buffer
-	if (argo::node_id() == 0) {
+	// TODO: Set == 0 when "page is local" replication bug if fixed!
+	if (argo::node_id() == 1) {
 		for (std::size_t i = 0; i < array_size; i++) {
 			array[i] = 1;
-			receiver[i] = 1;
 		}
 	}
 	argo::barrier();
 
-	// printf("Node %d: array[0] = %d\n", argo::node_id(), array[0]);
+	printf("----test: Node %d: array[0] = %d, receiver[0] = %d\n", argo::node_id(), array[0], receiver[0]);
 
-	if (argo::node_id() == argo_get_replnode(array)) {
-		argo::backend::get_repl_data((char*) array, (void *) receiver, array_size * sizeof(*array));
-		int count = 0;
-		for (std::size_t i = 0; i < array_size; i++) {
-			count += receiver[i];
-			printf("receiver[%lu] = %d\n", i, receiver[i]);
-		}
-		ASSERT_EQ(count, array_size);
+	argo::backend::get_repl_data((char *) array, receiver, array_size * sizeof(*array));
+	int count = 0;
+	for (std::size_t i = 0; i < array_size; i++) {
+		count += receiver[i];
+		printf("receiver[%lu] = %d\n", i, receiver[i]);
 	}
+	ASSERT_EQ(count, array_size);
 
 	delete [] receiver;
 	argo::codelete_array(array);
-	
 }
 
 /**

--- a/tests/replication.cpp
+++ b/tests/replication.cpp
@@ -54,58 +54,98 @@ protected:
 	}
 };
 
+// /**
+//  * @brief Simple test that a replicated char can be fetched by its host node
+//  */
+// TEST_F(replicationTest, completeReplicationLocal) {
+// 	// Test not relevant for single node
+// 	if (argo_number_of_nodes() == 1) {
+// 		ASSERT_TRUE(true);
+// 		return;
+// 	}
+
+// 	global_char val;
+// 	val = argo::conew_<char>(c_const);
+
+// 	*val += 1;		 // All nodes does this!
+// 	argo::barrier(); // Wait until writing is commited
+
+// 	char receiver = 'z';
+// 	if (argo::node_id() == argo_get_replnode(val.get())) {
+// 		argo::backend::get_repl_data(val, (void *)(&receiver), 1);
+// 		// printf("orignial val is %x = %c, repl val is %x = %c\n", *val, *val, receiver, receiver);
+// 		ASSERT_EQ(*val, receiver);
+// 	} else {
+// 		// Not target node; automatically passing
+// 		ASSERT_TRUE(true);
+// 	}
+// }
+
+// /**
+//  * @brief Test that a replicated char can be fetched by remote nodes
+//  */
+// TEST_F(replicationTest, completeReplicationRemote) {
+// 	// Test not relevant for single node
+// 	if (argo_number_of_nodes() == 1) {
+// 		ASSERT_TRUE(true);
+// 		return;
+// 	}
+
+// 	global_char val;
+// 	val = argo::conew_<char>(c_const);
+
+// 	*val += 1;
+// 	argo::barrier();
+
+// 	char receiver = 'z';
+// 	if (argo::node_id() != argo_get_replnode(val.get())) {
+// 		argo::backend::get_repl_data(val, (void *)&receiver, 1);
+// 		// printf("orignial val is %x = %c, repl val is %x = %c\n", *val, *val, receiver, receiver);
+// 		ASSERT_EQ(*val, receiver);
+// 	} else {
+// 		// Not target node; automatically passing
+// 		ASSERT_TRUE(true);
+// 	}
+// }
+
 /**
- * @brief Test that replicated data can be fetched by its host node
+ * @brief Test that a replicated array can be fetched locally and remotely
  */
-TEST_F(replicationTest, completeReplicationLocal) {
+TEST_F(replicationTest, completeReplicationArray) {
 	// Test not relevant for single node
 	if (argo_number_of_nodes() == 1) {
 		ASSERT_TRUE(true);
 		return;
 	}
 
-	global_char val;
-	val = argo::conew_<char>('a');
+	const std::size_t array_size = 10;
+	int* array = argo::conew_array<int>(array_size);
+	int* receiver = new int[array_size];
 
-	*val += 1;		 // All nodes does this!
-	argo::barrier(); // Wait until writing is commited
-
-	char receiver = 'z';
-	if (argo::node_id() == argo_get_replnode(val.get())) {
-		argo::backend::get_repl_data(val, (void *)(&receiver), 1);
-		// printf("orignial val is %x = %c, repl val is %x = %c\n", *val, *val, receiver, receiver);
-		ASSERT_EQ(*val, receiver);
-	} else {
-		// Not target node; automatically passing
-		ASSERT_TRUE(true);
+	// Initialize write buffer
+	if (argo::node_id() == 0) {
+		for (std::size_t i = 0; i < array_size; i++) {
+			array[i] = 1;
+			receiver[i] = 1;
+		}
 	}
-}
-
-/**
- * @brief Test that replicated data can be fetched by remote nodes
- */
-TEST_F(replicationTest, completeReplicationRemote) {
-	// Test not relevant for single node
-	if (argo_number_of_nodes() == 1) {
-		ASSERT_TRUE(true);
-		return;
-	}
-
-	global_char val;
-	val = argo::conew_<char>('a');
-
-	*val += 1;
 	argo::barrier();
 
-	char receiver = 'z';
-	if (argo::node_id() != argo_get_replnode(val.get())) {
-		argo::backend::get_repl_data(val, (void *)&receiver, 1);
-		// printf("orignial val is %x = %c, repl val is %x = %c\n", *val, *val, receiver, receiver);
-		ASSERT_EQ(*val, receiver);
-	} else {
-		// Not target node; automatically passing
-		ASSERT_TRUE(true);
+	// printf("Node %d: array[0] = %d\n", argo::node_id(), array[0]);
+
+	if (argo::node_id() == argo_get_replnode(array)) {
+		argo::backend::get_repl_data((char*) array, (void *) receiver, array_size * sizeof(*array));
+		int count = 0;
+		for (std::size_t i = 0; i < array_size; i++) {
+			count += receiver[i];
+			printf("receiver[%lu] = %d\n", i, receiver[i]);
+		}
+		ASSERT_EQ(count, array_size);
 	}
+
+	delete [] receiver;
+	argo::codelete_array(array);
+	
 }
 
 /**

--- a/tests/replication.cpp
+++ b/tests/replication.cpp
@@ -139,13 +139,13 @@ TEST_F(replicationTest, completeReplicationArray) {
 	}
 	argo::barrier();
 
-	printf("----test: Node %d: array[0] = %d, receiver[0] = %d\n", argo::node_id(), array[0], receiver[0]);
+	// printf("----test: Node %d: array[0] = %d, receiver[0] = %d\n", argo::node_id(), array[0], receiver[0]);
 
 	argo::backend::get_repl_data((char *) array, receiver, array_size * sizeof(*array));
 	int count = 0;
 	for (std::size_t i = 0; i < array_size; i++) {
 		count += receiver[i];
-		printf("receiver[%lu] = %d\n", i, receiver[i]);
+		// printf("receiver[%lu] = %d\n", i, receiver[i]);
 	}
 	ASSERT_EQ(count, array_size);
 


### PR DESCRIPTION
Added a test that an array is properly replicated and can be properly restored from the replicated data region, and removed some prints. One major problem was discovered, however, which as of yet has not been fixed: if the home node of a piece of data is the single writer, it will not replicate the data in the replicated node. This is because of the if branch in the handler checking if the current node is the home node of the page that caused the page fault. If it is, no call is ever made to `storepageDIFF`, only the local and remote directories are updated. This is a major problem since any piece of data whose home node is the only writer will have no redundancy. For now, all replication tests make sure to only write data from the replicated nodes. In that scenario everything works fine.