### PR TITLE
Starting to implement rebuilding

### DIFF
--- a/src/argo.hpp
+++ b/src/argo.hpp
@@ -121,7 +121,7 @@ namespace argo {
 		if (gptr_home == data_distribution::invalid_node_id) {
 			return data_distribution::invalid_node_id;
 		} else {
-			return (gptr_home + 1) % number_of_nodes();
+			return argo::backend::calc_repl_node_id(gptr_home);
 		}
 	}
 

--- a/src/backend/backend.hpp
+++ b/src/backend/backend.hpp
@@ -65,6 +65,14 @@ namespace argo {
 		 */
 		node_id_t repl_node_id();
 
+		/* CSPext: add function to calc replication node id */
+		/**
+		 * @brief get ArgoDSM repl node ID from given node id
+ 		 * @param n node id of the target node
+		 * @return repl node ID
+		 */
+		node_id_t calc_repl_node_id(argo::node_id_t n);
+
 		/**
 		 * @brief get total number of ArgoDSM nodes
 		 * @return total number of ArgoDSM nodes

--- a/src/backend/mpi/mpi.cpp
+++ b/src/backend/mpi/mpi.cpp
@@ -169,6 +169,11 @@ namespace argo {
 			return argo_get_rid();	// defined in swdsm.cpp
 		}
 
+		/* CSPext: add function to calculate replication node id */
+		node_id_t calc_repl_node_id(argo::node_id_t n) {
+			return argo_calc_rid(n);// defined in swdsm.cpp
+		}
+
 		node_id_t number_of_nodes() {
 			return argo_get_nodes();
 		}

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -560,7 +560,6 @@ void load_cache_entry(std::size_t aligned_access_offset) {
 
 		/* If another page occupies the cache index, begin to evict it. */
 		if((cacheControl[idx].tag != temp_addr) && (cacheControl[idx].tag != GLOBAL_NULL)){
-			printf("------load cache entry: evict\n");
 			void* old_ptr = static_cast<char*>(startAddr) + cacheControl[idx].tag;
 			void* temp_ptr = static_cast<char*>(startAddr) + temp_addr;
 
@@ -573,10 +572,8 @@ void load_cache_entry(std::size_t aligned_access_offset) {
 				argo_write_buffer->erase(idx);
 			}
 
-			printf("------load cache entry: unlock windows\n");
 			/* Ensure the writeback has finished */
 			for(int i = 0; i < numtasks; i++){
-				argo::node_id_t repl_node_i = _calc_rid(i);	// get replication node
 				if(barwindowsused[i] == 1){
 					MPI_Win_unlock(i, globalDataWindow[i]);
 					barwindowsused[i] = 0;

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -234,6 +234,21 @@ argo::node_id_t getID();
  */
 argo::node_id_t argo_get_nid();
 
+/* CSPext: Wrapping up a function to calculate the replication node */
+/**
+ * @brief give the replication node of current node id.
+ * @return node id of the corresponding replication node
+ */
+argo::node_id_t argo_get_rid();
+
+/* CSPext: A function to calculate the replication node */
+/**
+ * @brief give the replication node of one node id.
+ * @param n node id of the target node
+ * @return node id of the corresponding replication node
+ */
+argo::node_id_t argo_calc_rid(argo::node_id_t n);
+
 /**
  * @brief Gives number of ArgoDSM nodes
  * @return Number of ArgoDSM nodes
@@ -352,35 +367,6 @@ unsigned long get_classification_index(uint64_t addr);
  * @todo this should be moved in to a dedicated cache class
  */
 bool _is_cached(std::size_t addr);
-
-/* CSPext: Wrapping up a function to expose current node's globaldata start. */
-/**
- * @brief give the start of current node's globalData.
- * @return a pointer to the start of current node's globalData.
- */
-char* argo_get_globaldata_start();
-
-/* CSPext: Wrapping up a function to expose current node's repldata start. */
-/**
- * @brief give the start of current node's replData.
- * @return a pointer to the start of current node's replData.
- */
-char* argo_get_repldata_start();
-
-/* CSPext: Wrapping up a function to calculate the replication node */
-/**
- * @brief give the replication node of current node id.
- * @return node id of the corresponding replication node
- */
-argo::node_id_t argo_get_rid();
-
-/* CSPext: A function to calculate the replication node, used locally */
-/**
- * @brief give the replication node of one node id.
- * @param n node id of the target node
- * @return node id of the corresponding replication node
- */
-argo::node_id_t _calc_rid(argo::node_id_t n);
 
 /* CSPext: Copy data from the input pointer's repl node */
 /**

--- a/src/backend/singlenode/singlenode.cpp
+++ b/src/backend/singlenode/singlenode.cpp
@@ -113,6 +113,15 @@ namespace argo {
 			return (my_node_id + 1) % nodes;
 		}
 
+		/* CSPext: had to add this to keep backend.hpp defined */
+		node_id_t calc_repl_node_id(argo::node_id_t n) {
+			if (n < 0 || (unsigned)n >= nodes) {
+				return argo::data_distribution::invalid_node_id;
+			} else {
+				return (n + 1) % nodes;
+			}
+		}
+
 		node_id_t number_of_nodes() {
 			return nodes;
 		}

--- a/tests/replication.cpp
+++ b/tests/replication.cpp
@@ -92,7 +92,7 @@ TEST_F(replicationTest, completeReplicationRemote) {
 	}
 
 	global_char val;
-	val = argo::conew_<char>('a');
+	val = argo::conew_<char>('g');
 
 	*val += 1;
 	argo::barrier();


### PR DESCRIPTION
1. Exposed a function to calculate replication node for given node id.
2. Updated the function to calculate replication node for given pointer address. It now calls another function instead of calculating by itself.
3. Added node alternation table to check nodes that are down and the corresponding rebuilt node id.

Next step:
1. Modify `load_cache_entry`.  Before reading, check the alternation table.
2. Modify the same function. Check whether to use the default `globalData` and `globalDataWindow`.
3. To decide: probably need to do the same to `storepageDIFF`.
4. To decide: probably need to create the alternation table for replication data as well. What to do for the replData area on the lost node?
5. Create functions to detect node loss. To decide: how? MPI connection failure?
6. To decide: how to test? How to simulate a lost node?
7. Use test-and-set to rebuild the lost node. Only one node does the job and updates all alternation tables.