### PR TITLE
Erasure coding

### DIFF
--- a/src/data_distribution/base_distribution.hpp
+++ b/src/data_distribution/base_distribution.hpp
@@ -54,6 +54,14 @@ namespace argo {
 				/** @brief one node's share of the memory space */
 				static std::size_t size_per_node;
 
+				// CSPext: umber of data fragments (pages) to calculate parity on
+				static node_id_t data_fragments;
+
+				// CSPext: number of parity fragments to calculate for each set of data_fragments
+				static node_id_t parity_fragments;
+
+				// CSPext: note, data_fragments + parity_fragments == nodes
+
 			public:
 				/**
 				 * @brief set runtime parameters for global memory space
@@ -133,6 +141,31 @@ namespace argo {
 				 */
 				static char* get_ptr(const node_id_t homenode, const std::size_t offset) {
 					return start_address + homenode*size_per_node + offset;
+				}
+
+				// CSPext:
+
+				/**
+				 * @brief compute replication node of an address
+				 * 
+				 * @param ptr address to find replication node of
+				 * @return the computed replication node
+				 */
+
+				virtual node_id_t parity_node(char* const ptr) {
+					return invalid_node_id;
+				}
+
+				// CSPext:
+
+				/**
+				 * @brief compute the offset of a ptr in the backing store
+				 * on ptr's replication node
+				 * @param ptr address to find offset of
+				 * @return the backing store offset
+				 */
+				virtual std::size_t parity_offset(char* const ptr) {
+					return invalid_offset;
 				}
 		};
 		template<int i> node_id_t base_distribution<i>::nodes;

--- a/src/data_distribution/base_distribution.hpp
+++ b/src/data_distribution/base_distribution.hpp
@@ -153,6 +153,7 @@ namespace argo {
 				 */
 
 				virtual node_id_t parity_node(char* const ptr) {
+					(void)ptr;
 					return invalid_node_id;
 				}
 
@@ -165,6 +166,7 @@ namespace argo {
 				 * @return the backing store offset
 				 */
 				virtual std::size_t parity_offset(char* const ptr) {
+					(void)ptr;
 					return invalid_offset;
 				}
 		};

--- a/src/data_distribution/naive_distribution.hpp
+++ b/src/data_distribution/naive_distribution.hpp
@@ -62,7 +62,8 @@ namespace argo {
 				// CSPext:
 
 				virtual std::size_t parity_offset(char* const ptr) {
-					return local_offset(ptr) / (data_distribution::granularity * base_distribution<instance>::data_fragments);
+					std::size_t parity_page_number = local_offset(ptr) / (data_distribution::granularity * base_distribution<instance>::data_fragments);
+					return parity_page_number * data_distribution::granularity;
 				}
 
 

--- a/src/data_distribution/naive_distribution.hpp
+++ b/src/data_distribution/naive_distribution.hpp
@@ -55,14 +55,18 @@ namespace argo {
 				// CSPext:
 
 				virtual node_id_t parity_node(char* const ptr) {
-					// CSP: TODO: find parity node of an address
-					return invalid_node_id;
+					std::size_t nodes = base_distribution<instance>::nodes;
+					std::size_t local_page_number = local_offset(ptr) / data_distribution::granularity;
+					std::size_t cyclical_page_number = homenode(ptr) + (local_page_number * nodes);
+					std::size_t data_blocks = nodes - 1;
+					return (((cyclical_page_number / data_blocks) + 1) * data_blocks) % nodes;
+
 				}
 
 				// CSPext:
 
 				virtual std::size_t parity_offset(char* const ptr) {
-					std::size_t parity_page_number = local_offset(ptr) / (data_distribution::granularity * base_distribution<instance>::data_fragments);
+					std::size_t parity_page_number = local_offset(ptr) / (data_distribution::granularity * (base_distribution<instance>::nodes - 1));
 					return parity_page_number * data_distribution::granularity;
 				}
 

--- a/src/data_distribution/naive_distribution.hpp
+++ b/src/data_distribution/naive_distribution.hpp
@@ -51,6 +51,21 @@ namespace argo {
 				virtual std::size_t peek_local_offset (char* const ptr) {
 					return local_offset(ptr);
 				}
+
+				// CSPext:
+
+				virtual node_id_t parity_node(char* const ptr) {
+					// CSP: TODO: find parity node of an address
+					return invalid_node_id;
+				}
+
+				// CSPext:
+
+				virtual std::size_t parity_offset(char* const ptr) {
+					return local_offset(ptr) / (data_distribution::granularity * base_distribution<instance>::data_fragments);
+				}
+
+
 		};
 	} // namespace data_distribution
 } // namespace argo

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -51,6 +51,14 @@ namespace {
 	 */
 	const std::size_t default_allocation_block_size = 1ul<<4; // default: 16
 
+	// CSPext
+
+	/**
+	 * @brief default requested replication policy (if environment variable is unset)
+	 * @see @ref ARGO_REPLICATION_POLICY
+	 */
+	const std::size_t default_replication_policy = 0;
+
 	/**
 	 * @brief default requested load size (if environment variable is unset)
 	 * @see @ref ARGO_LOAD_SIZE
@@ -92,6 +100,14 @@ namespace {
 	 * @see @ref ARGO_ALLOCATION_BLOCK_SIZE
 	 */
 	const std::string env_allocation_block_size = "ARGO_ALLOCATION_BLOCK_SIZE";
+
+	// CSPext
+
+	/**
+	 * @brief environment variable used for requesting replication policy
+	 * @see @ref ARGO_REPLICATION_POLICY
+	 */
+	const std::string env_replication_policy = "ARGO_REPLICATION_POLICY";
 
 	/**
 	 * @brief environment variable used for requesting load size
@@ -136,6 +152,13 @@ namespace {
 	 * @brief allocation block size requested through the environment variable @ref ARGO_ALLOCATION_BLOCK_SIZE
 	 */
 	std::size_t value_allocation_block_size;
+
+	// CSPext
+
+	/**
+	 * @brief replication policy requested through the environment variable @ref ARGO_REPLICATION_POLICY
+	 */
+	std::size_t value_replication_policy;
 
 	/**
 	 * @brief load size requested through the environment variable @ref ARGO_LOAD_SIZE
@@ -205,6 +228,8 @@ namespace argo {
 
 			value_allocation_policy = parse_env<std::size_t>(env_allocation_policy, default_allocation_policy).second;
 			value_allocation_block_size = parse_env<std::size_t>(env_allocation_block_size, default_allocation_block_size).second;
+			// CSPext
+			value_replication_policy = parse_env<std::size_t>(env_replication_policy, default_replication_policy).second;
 			value_load_size = parse_env<std::size_t>(env_load_size, default_load_size).second;
 
 			is_initialized = true;
@@ -238,6 +263,13 @@ namespace argo {
 		std::size_t allocation_block_size() {
 			assert_initialized();
 			return value_allocation_block_size;
+		}
+
+		// CSPext
+
+		std::size_t replication_policy() {
+			assert_initialized();
+			return value_replication_policy;
 		}
 
 		std::size_t load_size() {

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -37,6 +37,10 @@
  * @details This environment variable can be accessed through
  *          @ref argo::env::allocation_policy() after argo::env::init() has been called.
  * 
+ * @envvar{ARGO_REPLICATION_POLICY} request a specific replication policy with a number
+ * @details This environment variable can be accessed through
+ *          @ref argo::env::replication_policy() after argo::env::init() has been called.
+ * 
  * @envvar{ARGO_ALLOCATION_BLOCK_SIZE} request a specific allocation block size in number of pages
  * @details This environment variable can be accessed through
  *          @ref argo::env::allocation_block_size() after argo::env::init() has been called.
@@ -102,6 +106,14 @@ namespace argo {
 		 * @see @ref ARGO_ALLOCATION_BLOCK_SIZE
 		 */
 		std::size_t allocation_block_size();
+
+		// CSPext
+
+		/**
+		 * @brief get the replication policy requested by environment variable
+		 * @return the requested replication policy as a number. 0 == complete replication, 1 == erasure code (n-1, 1)
+		 */
+		std::size_t replication_policy();
 
 		/**
 		 * @brief get the number of pages fetched remotely per load requested

--- a/tests/replication.cpp
+++ b/tests/replication.cpp
@@ -142,7 +142,7 @@ TEST_F(replicationTest, completeReplicationArray) {
 	// printf("----test: Node %d: array[0] = %d, receiver[0] = %d\n", argo::node_id(), array[0], receiver[0]);
 
 	argo::backend::get_repl_data((char *) array, receiver, array_size * sizeof(*array));
-	int count = 0;
+	unsigned long count = 0;
 	for (std::size_t i = 0; i < array_size; i++) {
 		count += receiver[i];
 		// printf("receiver[%lu] = %d\n", i, receiver[i]);


### PR DESCRIPTION
This PR will introduce the new environment variable ARGO_REPLICATION_POLICY.

0 represents complete replication, 1 represents erasure coding (n-1, 1).

This can be accessed by the function `env::replication_policy()`