### PR TITLE
Environment variable changes and additions

### DIFF
--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -904,12 +904,12 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 	GLOBAL_NULL=size_of_all+1;
 	size_of_chunk = argo_size/(numtasks); //part on each node
 	// CSPext
-	if (env::replication_policy() == 0) {
+	if (env::replication_policy() == 1) {
 		// complete replication
 		printf("COMPLETE REPLICATION\n");
 		size_of_replication = size_of_chunk;
 	}
-	else if (env::replication_policy() == 1) {
+	else if (env::replication_policy() == 2) {
 		// erasure coding (n-1, 1)
 		printf("EASURE CODING\n");
 		size_of_replication = size_of_chunk / (numtasks - 1);
@@ -1323,10 +1323,10 @@ void storepageDIFF(unsigned long index, unsigned long addr){
 			if(cnt > 0){
 				MPI_Put(&real[i-cnt], cnt, MPI_BYTE, homenode, offset+(i-cnt), cnt, MPI_BYTE, globalDataWindow[homenode]);
 				// CSPext: Update page on repl node
-				if (env::replication_policy() == 0) {
+				if (env::replication_policy() == 1) {
 					MPI_Put(&real[i-cnt], cnt, MPI_BYTE, repl_node, repl_offset+(i-cnt), cnt, MPI_BYTE, replDataWindow[repl_node]);
 				}
-				else if (env::replication_policy() == 1) {
+				else if (env::replication_policy() == 2) {
 					MPI_Accumulate(&real[i-cnt], cnt, MPI_BYTE, repl_node, repl_offset+(i-cnt), cnt, MPI_BYTE, MPI_BXOR, replDataWindow[repl_node]);
 				}
 				cnt = 0;
@@ -1336,10 +1336,10 @@ void storepageDIFF(unsigned long index, unsigned long addr){
 	if(cnt > 0){
 		MPI_Put(&real[i-cnt], cnt, MPI_BYTE, homenode, offset+(i-cnt), cnt, MPI_BYTE, globalDataWindow[homenode]);
 		// CSPext: Update page on repl node
-		if (env::replication_policy() == 0) {
+		if (env::replication_policy() == 1) {
 			MPI_Put(&real[i-cnt], cnt, MPI_BYTE, repl_node, repl_offset+(i-cnt), cnt, MPI_BYTE, replDataWindow[repl_node]);
 		}
-		else if (env::replication_policy() == 1) {
+		else if (env::replication_policy() == 2) {
 			MPI_Accumulate(&real[i-cnt], cnt, MPI_BYTE, repl_node, repl_offset+(i-cnt), cnt, MPI_BYTE, MPI_BXOR, replDataWindow[repl_node]);
 		}
 	}

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -904,14 +904,15 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 	GLOBAL_NULL=size_of_all+1;
 	size_of_chunk = argo_size/(numtasks); //part on each node
 	// CSPext
-	if (env::replication_policy() == 1) {
+	repl_policy = env::replication_policy();
+	if (repl_policy == 1) {
 		// complete replication
 		printf("COMPLETE REPLICATION\n");
 		size_of_replication = size_of_chunk;
 	}
-	else if (env::replication_policy() == 2) {
+	else if (repl_policy == 2) {
 		// erasure coding (n-1, 1)
-		printf("EASURE CODING - data fragments: %lu, parity fragments: %lu\n", env::replication_data_fragments(), env::replication_parity_fragments());
+		printf("ERASURE CODING - data fragments: %lu, parity fragments: %lu\n", env::replication_data_fragments(), env::replication_parity_fragments());
 		size_of_replication = size_of_chunk / (env::replication_data_fragments());
 		size_of_replication = ((size_of_replication / pagesize) + 1) * pagesize; // align with pagesize
 	}

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -911,8 +911,8 @@ void argo_initialize(std::size_t argo_size, std::size_t cache_size){
 	}
 	else if (env::replication_policy() == 2) {
 		// erasure coding (n-1, 1)
-		printf("EASURE CODING\n");
-		size_of_replication = size_of_chunk / (numtasks - 1);
+		printf("EASURE CODING - data fragments: %lu, parity fragments: %lu\n", env::replication_data_fragments(), env::replication_parity_fragments());
+		size_of_replication = size_of_chunk / (env::replication_data_fragments());
 		size_of_replication = ((size_of_replication / pagesize) + 1) * pagesize; // align with pagesize
 	}
 	sig::signal_handler<SIGSEGV>::install_argo_handler(&handler);

--- a/src/data_distribution/naive_distribution.hpp
+++ b/src/data_distribution/naive_distribution.hpp
@@ -61,13 +61,13 @@ namespace argo {
 						return 0;
 					}
 
-					if (env::replication_policy() == 0) {
+					if (env::replication_policy() == 1) {
 						return (peek_homenode(ptr) + 1) % nodes;
 					}
-					else if (env::replication_policy() == 1) {
+					else if (env::replication_policy() == 2) {
 						std::size_t local_page_number = local_offset(ptr) / data_distribution::granularity;
 						std::size_t cyclical_page_number = homenode(ptr) + (local_page_number * nodes);
-						std::size_t data_blocks = nodes - 1;
+						std::size_t data_blocks = env::replication_data_fragments();
 						return (((cyclical_page_number / data_blocks) + 1) * data_blocks) % nodes;
 					}
 					return invalid_node_id;
@@ -80,11 +80,11 @@ namespace argo {
 					if (nodes == 1) {
 						return local_offset(ptr);
 					}
-					if (env::replication_policy() == 0) {
+					if (env::replication_policy() == 1) {
 						return local_offset(ptr);
 					}
-					else if (env::replication_policy() == 1) {
-						std::size_t parity_page_number = local_offset(ptr) / (data_distribution::granularity * (base_distribution<instance>::nodes - 1));
+					else if (env::replication_policy() == 2) {
+						std::size_t parity_page_number = local_offset(ptr) / (data_distribution::granularity * env::replication_data_fragments());
 						return parity_page_number * data_distribution::granularity;
 					}
 					return invalid_offset;

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -57,7 +57,20 @@ namespace {
 	 * @brief default requested replication policy (if environment variable is unset)
 	 * @see @ref ARGO_REPLICATION_POLICY
 	 */
-	const std::size_t default_replication_policy = 0;
+	const std::size_t default_replication_policy = 1;
+
+	/**
+	 * @brief default number of data fragments in the erasure coding scheme
+	 * 
+	 */
+
+	const std::size_t default_replication_data_fragments = 3;
+
+	/**
+	 * @brief default number of data parity in the erasure coding scheme
+	 * 
+	 */
+	const std::size_t default_replication_parity_fragments = 1;
 
 	/**
 	 * @brief default requested load size (if environment variable is unset)
@@ -110,6 +123,18 @@ namespace {
 	const std::string env_replication_policy = "ARGO_REPLICATION_POLICY";
 
 	/**
+	 * @brief environment variable used for defining the number of data fragments
+	 * in the erasure coding scheme
+	 */
+	const std::string env_replication_data_fragments = "ARGO_REPLICATION_DATA_FRAGMENTS";
+
+	/**
+	 * @brief environment variable used for defining the number of parity fragments
+	 * in the erasure coding scheme
+	 */
+	const std::string env_replication_parity_fragments = "ARGO_REPLICATION_PARITY_FRAGMENTS";
+
+	/**
 	 * @brief environment variable used for requesting load size
 	 * @see @ref ARGO_LOAD_SIZE
 	 */
@@ -159,6 +184,17 @@ namespace {
 	 * @brief replication policy requested through the environment variable @ref ARGO_REPLICATION_POLICY
 	 */
 	std::size_t value_replication_policy;
+
+	/**
+	 * @brief replication data fragments requested through the environment variable @ref ARGO_REPLICATION_DATA_FRAGMENTS
+	 */
+	std::size_t value_replication_data_fragments;
+
+	/**
+	 * @brief replication parity fragments requested through the environmental variable @ref ARGO_REPLICATION_PARITY_FRAGMENTS
+	 * 
+	 */
+	std::size_t value_replication_parity_fragments;
 
 	/**
 	 * @brief load size requested through the environment variable @ref ARGO_LOAD_SIZE
@@ -230,6 +266,9 @@ namespace argo {
 			value_allocation_block_size = parse_env<std::size_t>(env_allocation_block_size, default_allocation_block_size).second;
 			// CSPext
 			value_replication_policy = parse_env<std::size_t>(env_replication_policy, default_replication_policy).second;
+			value_replication_data_fragments = parse_env<std::size_t>(env_replication_data_fragments, default_replication_data_fragments).second;
+			value_replication_parity_fragments = parse_env<std::size_t>(env_replication_parity_fragments, default_replication_parity_fragments).second;
+			// CSPext end
 			value_load_size = parse_env<std::size_t>(env_load_size, default_load_size).second;
 
 			is_initialized = true;
@@ -271,6 +310,17 @@ namespace argo {
 			assert_initialized();
 			return value_replication_policy;
 		}
+
+		std::size_t replication_data_fragments() {
+			assert_initialized();
+			return value_replication_data_fragments;
+		}
+
+		std::size_t replication_parity_fragments() {
+			assert_initialized();
+			return value_replication_parity_fragments;
+		}
+		// CSPext end
 
 		std::size_t load_size() {
 			assert_initialized();

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -64,7 +64,7 @@ namespace {
 	 * 
 	 */
 
-	const std::size_t default_replication_data_fragments = 3;
+	const std::size_t default_replication_data_fragments = 1;
 
 	/**
 	 * @brief default number of data parity in the erasure coding scheme

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -116,6 +116,20 @@ namespace argo {
 		std::size_t replication_policy();
 
 		/**
+		 * @brief get the replication data fragments requested by environment variable
+		 * @return the requested replication data fragments as a number
+		 */
+		std::size_t replication_data_fragments();
+
+		/**
+		 * @brief get the replication parity fragments requested by environment variable
+		 * @return the requested replication parity fragments as a number
+		 */
+		std::size_t replication_parity_fragments();
+
+		// CSPext end
+
+		/**
 		 * @brief get the number of pages fetched remotely per load requested
 		 * by environment variable
 		 * @return the number of pages

--- a/tests/replication.cpp
+++ b/tests/replication.cpp
@@ -60,7 +60,7 @@ protected:
  * replication
  */
 TEST_F(replicationTest, localCharCR) {
-	if (argo_number_of_nodes() == 1 || argo::env::replication_policy() != 0) {
+	if (argo_number_of_nodes() == 1 || argo::env::replication_policy() != 1) {
 		return;
 	}
 	
@@ -82,7 +82,7 @@ TEST_F(replicationTest, localCharCR) {
  * @brief Test that a replicated char can be fetched by remote nodes using complete replication
  */
 TEST_F(replicationTest, remoteCharCR) {
-	if (argo_number_of_nodes() == 1 || argo::env::replication_policy() != 0) {
+	if (argo_number_of_nodes() == 1 || argo::env::replication_policy() != 1) {
 		return;
 	}
 
@@ -105,7 +105,7 @@ TEST_F(replicationTest, remoteCharCR) {
  * replication
  */
 TEST_F(replicationTest, arrayCR) {
-	if (argo_number_of_nodes() == 1 || argo::env::replication_policy() != 0) {
+	if (argo_number_of_nodes() == 1 || argo::env::replication_policy() != 1) {
 		return;
 	}
 
@@ -136,7 +136,7 @@ TEST_F(replicationTest, arrayCR) {
 }
 
 TEST_F(replicationTest, charEC) {
-	if (argo_number_of_nodes() == 1 || argo::env::replication_policy() != 1) {
+	if (argo_number_of_nodes() == 1 || argo::env::replication_policy() != 2) {
 		return;
 	}
 
@@ -160,7 +160,7 @@ TEST_F(replicationTest, charEC) {
  * @brief Test that the system can recover from a node going down using complete replication
  */
 TEST_F(replicationTest, nodeKillRebuildCR) {
-	if (argo_number_of_nodes() == 1 || argo::env::replication_policy() != 0) {
+	if (argo_number_of_nodes() == 1 || argo::env::replication_policy() != 1) {
 		return;
 	}
 

--- a/tests/replication.cpp
+++ b/tests/replication.cpp
@@ -156,6 +156,47 @@ TEST_F(replicationTest, charEC) {
 	ASSERT_EQ(*val^prev_repl_val, receiver);
 }
 
+TEST_F(replicationTest, arrayEC) {
+	if (argo_number_of_nodes() == 1 || argo::env::replication_policy() != 2) {
+		return;
+	}
+
+	const std::size_t array_size = 10;
+	int* array = argo::conew_array<int>(array_size);
+	int* receiver = new int[array_size];
+	int* prev_val_array = new int[array_size];
+
+	for (std::size_t i = 0; i < array_size; i++) {
+		prev_val_array[i] = 0;
+	}
+
+	argo::backend::get_repl_data((char *) array, prev_val_array, array_size * sizeof(*array));
+	argo::barrier();
+
+	for (std::size_t i = 0; i < array_size; i++) {
+		receiver[i] = 0;
+	}
+
+	if (argo::node_id() == 0) {
+		for (std::size_t i = 0; i < array_size; i++) {
+			array[i] = 1;
+		}
+	}
+	argo::barrier();
+
+	argo::backend::get_repl_data((char *) array, receiver, array_size * sizeof(*array));
+	unsigned long count = 0;
+	unsigned long count2 = 0;
+	for (std::size_t i = 0; i < array_size; i++) {
+		count += receiver[i];
+		count2 += array[i]^prev_val_array[i];
+	}
+	ASSERT_EQ(count, count2);
+
+	delete [] receiver;
+	argo::codelete_array(array);
+}
+
 /**
  * @brief Test that the system can recover from a node going down using complete replication
  */


### PR DESCRIPTION
This PR introduces two new environment variables `ARGO_REPLICATION_DATA_FRAGEMNTS` `ARGO_REPLICATION_PARITY_FRAGMENTS` which are used to determine what kind of erasure coding to use. The default value is 1 for both variables.

It also changes the interpretation of the environment variable `ARGO_REPLICATION_POLICY`.
0 == no replication (not implemented)
1 == complete replication
2 == erasure coding