### PR TITLE
Fixed support for no replication, updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 docs/_site/
 build
+install
 .vscode
 gtest-1.7.0
 *.swp

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -138,7 +138,7 @@ MPI_Win* node_alter_tbl_window;
 std::size_t vm_map_offset_record;
 /** @brief size of this process replication address space */
 unsigned long size_of_replication;
-/** @brief size of this process replication address space */
+/** @brief Whether to use replication or not */
 bool useReplication;
 
 /*First-Touch policy*/

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -525,7 +525,7 @@ void load_cache_entry(std::size_t aligned_access_offset) {
 	/* CSP ext: look up alter table. Keep home_node for comparison */
 	argo::node_id_t home_node = get_homenode(aligned_access_offset);
 	argo::node_id_t load_node = home_node;
-	if (env::replication_policy() != 0) {
+	if (useReplication) {
 		home_node = get_homenode(aligned_access_offset);
 		load_node = node_alter_tbl[home_node].alter_home_id;
 	}
@@ -555,7 +555,7 @@ void load_cache_entry(std::size_t aligned_access_offset) {
 			 *  which goes into the definition of global_ptr? Maybe not...?
 			 * */
 			argo::node_id_t temp_node = peek_homenode(temp_addr);
-			if (env::replication_policy() != 0) {
+			if (useReplication) {
 				temp_node = node_alter_tbl[peek_homenode(temp_addr)].alter_home_id;
 			}
 			const std::size_t temp_offset = peek_offset(temp_addr);

--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -141,7 +141,6 @@ unsigned long size_of_replication;
 /** @brief size of this process replication address space */
 bool useReplication;
 
-
 /*First-Touch policy*/
 /** @brief  Holds the owner and backing offset of a page */
 std::uintptr_t *global_owners_dir;

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -111,7 +111,8 @@ namespace argo {
 
 		/**
 		 * @brief get the replication policy requested by environment variable
-		 * @return the requested replication policy as a number. 0 == complete replication, 1 == erasure code (n-1, 1)
+		 * @return the requested replication policy as a number:
+		 * 0 == no replication, 1 == complete replication, 2 == erasure code (n-1, 1)
 		 */
 		std::size_t replication_policy();
 


### PR DESCRIPTION
Added more if-statements to be able to use ArgoDSM without any replication by setting the environment variable `ARGO_REPLICATION_POLICY` to 0. The major performance penalties are now avoided, but some assignments only useful for replication schemes will still occur, not to mention the if-statements themselves. I believe the costs of these are small enough to be ignored.

I also updated gitignore with the folder name `install` which a lot of benchmarks use as the default install directory for ArgoDSM.