### PR TITLE
Rebuild tests

### DIFF
--- a/src/backend/mpi/swdsm.cpp
+++ b/src/backend/mpi/swdsm.cpp
@@ -1813,9 +1813,6 @@ void lost_node_data_recovery(argo::node_id_t dead_node) {
 						for (check_addr = 0; check_addr < addr_max; check_addr += pagesize) {
 							check_home_id = peek_homenode(check_addr);
 							check_offset = peek_offset(check_addr);
-							//if (page_addr == 4194304) {
-							//	fprintf(stderr, "%d: %lu on dead node; checking %lu\n", argo_get_nid(), page_addr, check_addr);
-							//}
 							if (check_addr != page_addr
 									&& get_replication_node(check_addr) == page_repl_id
 									&& get_replication_offset(check_addr) == page_repl_offset) {

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -114,8 +114,8 @@ typedef struct node_alternation_table {
 	char* alter_globalData;
 	/** @brief new MPI window. Initialized to NULL. Delay assignment to use time. */
 	MPI_Win alter_globalDataWindow;
-	/** @brief flag to create the window. Need this in case of recreating windows. */
-	bool refresh_globalDataWindow;
+	/** @brief flag to indicate a just-finished recovery. May trigger local updates. */
+	bool just_recovered;
 	/** @brief altered replicated node id. Initialized to the record's home id. */
 	argo::node_id_t alter_repl_id;
 	/** @brief new replData ptr (address on alter node). Initialized to NULL. */
@@ -407,10 +407,10 @@ void argo_test_interface_rebuild(argo::node_id_t dead_node);
 
 /* CSPext: Create or re-create globalDataWindow */
 /**
- * @brief Check flag in the table and update MPI window.
+ * @brief Check flag in the table, update MPI windows, update skipped repl pages.
  * @param tbl Pointer to table.
  * */
-void node_alter_tbl_create_globalDatawindow(node_alternation_table *tbl);
+void local_check_after_recovery(node_alternation_table *tbl);
 
 /* CSPext: Create or re-create replDataWindow */
 /**

--- a/src/backend/mpi/swdsm.h
+++ b/src/backend/mpi/swdsm.h
@@ -124,8 +124,8 @@ typedef struct node_alternation_table {
 	MPI_Win alter_replDataWindow;
 	/** @brief flag to create the repl window. Need this in case of recreating windows. */
 	bool refresh_replDataWindow;
-	/** @brief flag to block others from rebuilding this node's home node. */
-	bool rebuilding;
+	/** @brief flag to block others from recovering this node's preceeding node. */
+	bool recovering;
 } node_alternation_table;
 
 /*constants for control values*/
@@ -391,16 +391,16 @@ unsigned long get_classification_index(uint64_t addr);
  */
 bool _is_cached(std::size_t addr);
 
-/* CSPext: Node rebuild function */
+/* CSPext: Node data revocery function */
 /**
- * @brief Start rebuilding (or access redirection?) process for a dead node.
+ * @brief Start data recovering (rebuild or access redirecting) process for a dead node.
  * @param dead_node Id of the node which is down.
  * */
-void redundancy_rebuild(argo::node_id_t dead_node);
+void lost_node_data_recovery(argo::node_id_t dead_node);
 
-/* CSPext: Exposed rebuild function for testing purpose */
+/* CSPext: Exposed data_recovery function for testing purpose */
 /**
- * @brief Calls redundancy_rebuild. Exposed in argo::backend namespace.
+ * @brief Calls lost_node_data_recovery. Exposed in argo::backend namespace.
  * @param dead_node Id of the node which is down.
  * */
 void argo_test_interface_rebuild(argo::node_id_t dead_node);

--- a/src/data_distribution/naive_distribution.hpp
+++ b/src/data_distribution/naive_distribution.hpp
@@ -84,7 +84,21 @@ namespace argo {
 						return local_offset(ptr);
 					}
 					else if (env::replication_policy() == 2) {
-						std::size_t parity_page_number = local_offset(ptr) / (data_distribution::granularity * env::replication_data_fragments());
+						std::size_t a = nodes, b = env::replication_data_fragments(), r = 0;
+						std::size_t lcm = 0;
+						/* Find gcd of nodes and fragments */
+						while (b != 0) {
+							r = a % b;
+							a = b;
+							b = r;
+						}
+						/* Calculate lcm of nodes and fragments */
+						lcm = nodes * env::replication_data_fragments() / a;
+
+						std::size_t local_page_number = local_offset(ptr) / data_distribution::granularity;
+						std::size_t cyclical_page_number = homenode(ptr) + (local_page_number * nodes);
+						//std::size_t parity_page_number = local_offset(ptr) / (data_distribution::granularity * env::replication_data_fragments());
+						std::size_t parity_page_number = cyclical_page_number / lcm;
 						return parity_page_number * data_distribution::granularity;
 					}
 					return invalid_offset;

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -54,7 +54,7 @@ namespace {
 	// CSPext
 
 	/**
-	 * @brief default requested replication policy (if environment variable is unset)
+	 * @brief default requested replication policy (if environment variable is unset). 0 for none; 1 for complete rep; 2 for EC
 	 * @see @ref ARGO_REPLICATION_POLICY
 	 */
 	const std::size_t default_replication_policy = 1;
@@ -73,13 +73,19 @@ namespace {
 	const std::size_t default_replication_parity_fragments = 1;
 
 	/**
+	 * @brief default data recovery policy. 0 for redirecting; 1 for rebuilding
+	 * @see @ref ARGO_REPLICATION_RECOVERY_POLICY
+	 */
+	const std::size_t default_replication_recovery_policy = 0;
+
+	/**
 	 * @brief default requested load size (if environment variable is unset)
 	 * @see @ref ARGO_LOAD_SIZE
 	 */
 	const std::size_t default_load_size = 8;
 
 	/**
-	 * @brief environment variable used for requesting memory size
+	 * @brief environment variable used for rYoequesting memory size
 	 * @see @ref ARGO_MEMORY_SIZE
 	 */
 	const std::string env_memory_size = "ARGO_MEMORY_SIZE";
@@ -133,6 +139,12 @@ namespace {
 	 * in the erasure coding scheme
 	 */
 	const std::string env_replication_parity_fragments = "ARGO_REPLICATION_PARITY_FRAGMENTS";
+
+	/**
+	 * @brief environment variable used for requesting default data recovery policy
+	 * @see @ref ARGO_REPLICATION_RECOVERY_POLICY
+	 */
+	const std::string env_replication_recovery_policy = "ARGO_REPLICATION_RECOVERY_POLICY";
 
 	/**
 	 * @brief environment variable used for requesting load size
@@ -195,6 +207,11 @@ namespace {
 	 * 
 	 */
 	std::size_t value_replication_parity_fragments;
+
+	/**
+	 * @brief default data recovery policy requested through the environment variable @ref ARGO_REPLICATION_RECOVERY_POLICY
+	 */
+	std::size_t value_replication_recovery_policy;
 
 	/**
 	 * @brief load size requested through the environment variable @ref ARGO_LOAD_SIZE
@@ -268,6 +285,7 @@ namespace argo {
 			value_replication_policy = parse_env<std::size_t>(env_replication_policy, default_replication_policy).second;
 			value_replication_data_fragments = parse_env<std::size_t>(env_replication_data_fragments, default_replication_data_fragments).second;
 			value_replication_parity_fragments = parse_env<std::size_t>(env_replication_parity_fragments, default_replication_parity_fragments).second;
+			value_replication_recovery_policy = parse_env<std::size_t>(env_replication_recovery_policy, default_replication_recovery_policy).second;
 			// CSPext end
 			value_load_size = parse_env<std::size_t>(env_load_size, default_load_size).second;
 
@@ -319,6 +337,11 @@ namespace argo {
 		std::size_t replication_parity_fragments() {
 			assert_initialized();
 			return value_replication_parity_fragments;
+		}
+
+		std::size_t replication_recovery_policy() {
+			assert_initialized();
+			return value_replication_recovery_policy;
 		}
 		// CSPext end
 

--- a/src/env/env.hpp
+++ b/src/env/env.hpp
@@ -127,6 +127,11 @@ namespace argo {
 		 */
 		std::size_t replication_parity_fragments();
 
+		/**
+		 * @brief get the replication recovery policy requested by environment variable
+		 * @return the requested replication recovery policy as a number
+		 */
+		std::size_t replication_recovery_policy();
 		// CSPext end
 
 		/**

--- a/tests/replication.cpp
+++ b/tests/replication.cpp
@@ -219,7 +219,7 @@ TEST_F(replicationTest, nodeKillRebuildCR) {
 
 	argo::barrier();
 	argo::backend::test_interface_rebuild(0);
-	// *val += 1;
+	*val += 1;
 	argo::barrier();
 
 	// kill_node(argo_get_homenode(val));
@@ -228,7 +228,7 @@ TEST_F(replicationTest, nodeKillRebuildCR) {
 	// Note: The killed node will still run all the code here since it doesn't actually crash
 
 	if (argo_get_homenode(val) == argo::node_id()) {
-		ASSERT_EQ(copy, *val); // val should point to the replicated node now
+		ASSERT_EQ(copy += 2, *val); // val should point to the replicated node now
 	}
 }
 

--- a/tests/replication.cpp
+++ b/tests/replication.cpp
@@ -157,7 +157,7 @@ TEST_F(replicationTest, charEC) {
 
 	char receiver = 'z';
 	argo::backend::get_repl_data(val, (void *)(&receiver), 1);
-	ASSERT_EQ(*val^prev_repl_val, receiver);
+	ASSERT_EQ(prev_repl_val + 1, receiver);
 }
 
 TEST_F(replicationTest, arrayEC) {
@@ -193,7 +193,8 @@ TEST_F(replicationTest, arrayEC) {
 	unsigned long count2 = 0;
 	for (std::size_t i = 0; i < array_size; i++) {
 		count += receiver[i];
-		count2 += array[i]^prev_val_array[i];
+		//count2 += array[i]^prev_val_array[i];
+		count2 += 1;
 	}
 	ASSERT_EQ(count, count2);
 
@@ -205,7 +206,7 @@ TEST_F(replicationTest, arrayEC) {
  * @brief Test that the system can recover from a node going down using complete replication
  */
 TEST_F(replicationTest, nodeKillRebuildCR) {
-	if (argo_number_of_nodes() == 1 || argo::env::replication_policy() != 1) {
+	if (argo_number_of_nodes() == 1 || argo::env::replication_policy() != 2) {
 		return;
 	}
 
@@ -242,7 +243,8 @@ TEST_F(replicationTest, nodeKillRebuildCR) {
 	// update_alteration_table(argo_get_homenode(val));
 	// Note: The killed node will still run all the code here since it doesn't actually crash
 
-	if (argo_get_homenode(val) == argo::node_id()) {
+	if (argo_get_homenode(val) != argo::node_id()) {
+		printf("Looking at data on node %d: ", argo::node_id());
 		ASSERT_EQ((char)(copy + 4), *val); // val should point to the replicated node now
 	}
 }
@@ -277,7 +279,7 @@ TEST_F(replicationTest, alternationTable) {
  * @return 0 if success
  */
 int main(int argc, char **argv) {
-	char rep_policy[] = "ARGO_REPLICATION_POLICY=1";
+	char rep_policy[] = "ARGO_REPLICATION_POLICY=2";
 	char ec_frag[] = "ARGO_REPLICATION_DATA_FRAGMENTS=3";
 	putenv(rep_policy);
 	putenv(ec_frag);

--- a/tests/replication.cpp
+++ b/tests/replication.cpp
@@ -220,7 +220,7 @@ TEST_F(replicationTest, nodeKillRebuildCR) {
 
 	argo::barrier();
 	argo::backend::test_interface_rebuild(0);
-	*val += 1;
+	printf("%c\n", *val);// += 1;
 	argo::barrier();
 
 	// kill_node(argo_get_homenode(val));

--- a/tests/replication.cpp
+++ b/tests/replication.cpp
@@ -26,7 +26,7 @@ using global_uint = typename argo::data_distribution::global_ptr<unsigned>;
 using global_intptr = typename argo::data_distribution::global_ptr<int *>;
 
 /** @brief ArgoDSM memory size */
-constexpr std::size_t size = 1 << 24; // 16MB
+constexpr std::size_t size = 1 << 16; // 16MB
 /** @brief ArgoDSM cache size */
 constexpr std::size_t cache_size = size;
 
@@ -194,7 +194,7 @@ TEST_F(replicationTest, arrayEC) {
 	for (std::size_t i = 0; i < array_size; i++) {
 		count += receiver[i];
 		//count2 += array[i]^prev_val_array[i];
-		count2 += 1;
+		count2 += array[2];
 	}
 	ASSERT_EQ(count, count2);
 
@@ -253,7 +253,7 @@ TEST_F(replicationTest, nodeKillRebuildCR) {
  * @brief Test that the node alternation table is working
  */
 TEST_F(replicationTest, alternationTable) {
-	if (argo::node_id() != 0 || argo_number_of_nodes() == 1 || argo::env::replication_policy() != 5) {
+	if (argo::node_id() != 0 || argo_number_of_nodes() == 1 || argo::env::replication_policy() != 999) {
 		return;
 	}
 

--- a/tests/replication.cpp
+++ b/tests/replication.cpp
@@ -205,7 +205,7 @@ TEST_F(replicationTest, arrayEC) {
  * @brief Test that the system can recover from a node going down using complete replication
  */
 TEST_F(replicationTest, nodeKillRebuildCR) {
-	if (argo_number_of_nodes() == 1 || argo::env::replication_policy() != 2) {
+	if (argo_number_of_nodes() == 1 || argo::env::replication_policy() != 1) {
 		return;
 	}
 
@@ -220,7 +220,21 @@ TEST_F(replicationTest, nodeKillRebuildCR) {
 
 	argo::barrier();
 	argo::backend::test_interface_rebuild(0);
-	printf("%c\n", *val);// += 1;
+	if (argo::node_id() == 1){
+		*val += 1;
+	}
+	argo::barrier();
+	if (argo::node_id() == 2){
+		*val += 1;
+	}
+	argo::barrier();
+	if (argo::node_id() == 3){
+		*val += 1;
+	}
+	argo::barrier();
+	if (argo::node_id() == 1){
+		*val += 1;
+	}
 	argo::barrier();
 
 	// kill_node(argo_get_homenode(val));
@@ -229,7 +243,7 @@ TEST_F(replicationTest, nodeKillRebuildCR) {
 	// Note: The killed node will still run all the code here since it doesn't actually crash
 
 	if (argo_get_homenode(val) == argo::node_id()) {
-		ASSERT_EQ(copy += 2, *val); // val should point to the replicated node now
+		ASSERT_EQ((char)(copy + 4), *val); // val should point to the replicated node now
 	}
 }
 
@@ -237,19 +251,21 @@ TEST_F(replicationTest, nodeKillRebuildCR) {
  * @brief Test that the node alternation table is working
  */
 TEST_F(replicationTest, alternationTable) {
-	if (argo::node_id() != 0 || argo_number_of_nodes() == 1 || argo::env::replication_policy() != 2) {
+	if (argo::node_id() != 0 || argo_number_of_nodes() == 1 || argo::env::replication_policy() != 5) {
 		return;
 	}
 
 	/* Verify the repl page calculation */
 	std::size_t addr = 0;//argo::virtual_memory::start_address();
-	for (addr = 0; addr < (argo::virtual_memory::size()); addr += 4096) {
+	for (addr = 0; addr < (argo::backend::global_size()); addr += 4096) {
 		global_char gptr(reinterpret_cast<char*>(
 			addr + reinterpret_cast<unsigned long>(argo::virtual_memory::start_address())), false, false);
-		printf("%lu: on node %d, offset %lu; repl to %d, offset: %lu\n", 
+		printf("%lu: on node %d, offset %lu; repl to %d, offset: %lu, vm size: %lu\n", 
 						addr,
 					   	gptr.peek_node(), gptr.peek_offset(),
-						gptr.get_replication_node(), gptr.get_replication_offset());
+						gptr.get_replication_node(), 
+						gptr.get_replication_offset(),
+						argo::backend::global_size());
 	}
 	//ASSERT_EQ(false, true); // to see outputs
 }
@@ -261,7 +277,7 @@ TEST_F(replicationTest, alternationTable) {
  * @return 0 if success
  */
 int main(int argc, char **argv) {
-	char rep_policy[] = "ARGO_REPLICATION_POLICY=2";
+	char rep_policy[] = "ARGO_REPLICATION_POLICY=1";
 	char ec_frag[] = "ARGO_REPLICATION_DATA_FRAGMENTS=3";
 	putenv(rep_policy);
 	putenv(ec_frag);


### PR DESCRIPTION
Let's merge a newer version with at least fully implemented redirect. Rebuild is still 50% complete (only supporting 1 additional MPI window each node and only CR)